### PR TITLE
Add single vector option

### DIFF
--- a/R/get_features.R
+++ b/R/get_features.R
@@ -9,14 +9,24 @@
 
 
 get_features <-
-  function(string1, string2){
-    tmp = expand.grid(string1, string2)
-    tmp$osa = stringdist::stringdist(tmp[,1], tmp[,2], method = "osa")
-    tmp$cosine = stringdist::stringdist(tmp[,1], tmp[,2], method = "cosine")
-    tmp$jaccard = stringdist::stringdist(tmp[,1], tmp[,2], method = "jaccard")
-    tmp$jw = stringdist::stringdist(tmp[,1], tmp[,2], method = "jw")
-    tmp$lcs = stringdist::stringdist(tmp[,1], tmp[,2], method = "lcs")
-    tmp$qgram = stringdist::stringdist(tmp[,1], tmp[,2], method = "qgram")
-    tmp$soundex = stringdist::stringdist(tmp[,1], tmp[,2], method = "soundex")
-    return(tmp)  
+  function(string1, string2 = NULL) {
+    if (is.null(string2)) {
+      tmp = string1 |>
+        length() |>
+        combn(2) |>
+        split(1:2) |>
+        lapply(\(x) string1[x]) |>
+        as.data.frame() |>
+        setNames(c("Var1", "Var2"))
+    } else {
+      tmp = expand.grid(string1, string2)
+    }
+    tmp$osa = stringdist::stringdist(tmp[, 1], tmp[, 2], method = "osa")
+    tmp$cosine = stringdist::stringdist(tmp[, 1], tmp[, 2], method = "cosine")
+    tmp$jaccard = stringdist::stringdist(tmp[, 1], tmp[, 2], method = "jaccard")
+    tmp$jw = stringdist::stringdist(tmp[, 1], tmp[, 2], method = "jw")
+    tmp$lcs = stringdist::stringdist(tmp[, 1], tmp[, 2], method = "lcs")
+    tmp$qgram = stringdist::stringdist(tmp[, 1], tmp[, 2], method = "qgram")
+    tmp$soundex = stringdist::stringdist(tmp[, 1], tmp[, 2], method = "soundex")
+    return(tmp)
   }

--- a/R/get_features.R
+++ b/R/get_features.R
@@ -11,13 +11,10 @@
 get_features <-
   function(string1, string2 = NULL) {
     if (is.null(string2)) {
-      tmp = string1 |>
-        length() |>
-        combn(2) |>
-        split(1:2) |>
-        lapply(\(x) string1[x]) |>
-        as.data.frame() |>
-        setNames(c("Var1", "Var2"))
+      tmp = combn(length(string1), 2) # positions for combinations of unordered pairs
+      tmp = split(tmp, 1:2) # split rows of matrix
+      tmp = as.data.frame(lapply(tmp, \(x) string1[x])) # get elements based on positions
+      names(tmp) <- c("Var1", "Var2") # Rename for compatibility with rest of code
     } else {
       tmp = expand.grid(string1, string2)
     }

--- a/R/stringmatch.R
+++ b/R/stringmatch.R
@@ -1,7 +1,7 @@
 #' Generate a string distance score for all combinations of two vectors
 #'
 #' @param string1 A character vector
-#' @param string2 A character vector
+#' @param string2 A character vector. If no second vector is provided, the first is compared to itself.
 #' @param trainingset If NULL, use the base model. Otherwise, a data frame with columns A, B, and y corresponding to string1, string2, and a training label
 #' @param feature.importances If TRUE, returns feature importances.
 #' @return A data frame of rows length(string1) * length(string2) with columns for each string distance metric as well as a model-produced score
@@ -12,7 +12,7 @@
 
 
 stringmatch <-
-  function(string1, string2,
+  function(string1, string2 = NULL,
            trainingset = NULL,
            feature.importances = FALSE){
     data(train)
@@ -22,44 +22,44 @@ stringmatch <-
       if(!all(c("A", "B", "y") %in% colnames(trainingset))){
         stop("The columns of trainingset must include 'A', 'B', and 'y'")
       }
-      
+
       ## Calculate stringdist for new training set
       newtrain = get_features(trainingset$A, trainingset$B)
       colnames(newtrain)[1:2] = c("amicus", "bonica")
-      
+
       ## Add in the truth vector
       hash = paste0(trainingset$A, trainingset$B)
       hash2 = paste0(newtrain$amicus, newtrain$bonica)
       newtrain$match = 0
       newtrain$match[hash2 %in% hash] = 1
       newtrain = newtrain[,colnames(train)]
-      
+
       ## Append the new trainingset to the old one and generate the model
       train = rbind(train, newtrain)
       m = ranger::ranger(x = train %>% select(osa:soundex),
                        y = factor(train$match),
                       probability = TRUE)
-      
-    } 
-    
+
+    }
+
     ## Calculate stringdist for string1, string2
     feats = get_features(string1, string2)
     feats = feats %>% filter(!is.na(Var1),!is.na(Var2))
-    
+
     ## Run the prediction
     preds = predict(m, data = feats)
-    
+
     feats$pred = preds$predictions[,2]
-    
+
     ## Return feature importances too
     if(feature.importances){
       out = list(feats, ranger::importance(m))
     } else {
       out = list(feats)
     }
-    
+
     ## Return a data set of predictions
     return(out)
-    
+
   }
 


### PR DESCRIPTION
As is, `stringmatch()` requires two vector inputs. However, in a deduplication task you want to compare a vector to itself. It is not only clunky to have to enter the same argument twice, it also means longer computation times. This PR solves this by adding code to `get_features()` to generate a features frame for the single vector case. 